### PR TITLE
Enables multi-GPU training for CoAE and removes memory leaks

### DIFF
--- a/baselines/CoAE/trainval_net.py
+++ b/baselines/CoAE/trainval_net.py
@@ -501,7 +501,7 @@ if __name__ == '__main__':
       args_val = copy.deepcopy(args)
       args_val.imdbval_name = args.dataset_val
 
-      mAP = test(args_val, model=fasterRCNN)
+      mAP = test(args_val, model=fasterRCNN.module.state_dict(), network=args.net)
 
       if mAP > best_model_mAP:
           # save the model as the current best

--- a/os2d/engine/evaluate.py
+++ b/os2d/engine/evaluate.py
@@ -125,6 +125,7 @@ def evaluate(dataloader, net, cfg, criterion=None, print_per_class_results=False
                                             class_image_augmentation=cfg.eval.class_image_augmentation)
 
         if cfg.is_cuda:
+            del loc_targets_pyramid, losses_iter, class_targets_pyramid, image_class_scores_pyramid, transform_corners_pyramid
             torch.cuda.empty_cache()
 
     # normalize by number of steps


### PR DESCRIPTION
Fixes #37. Multi-GPU training for CoAE caused errors [discussion](https://discuss.pytorch.org/t/training-network-with-multiple-outputs-with-multi-gpus/6344). The updates enable multi-GPU training and single-GPU validation

Fixes #41. Validation in OS2D caused OOM during evaluation (for large datasets) due to variable persistence. The updates delete the variables from GPU RAM that are no longer needed.